### PR TITLE
Fixing Makefile to use the cURL Docker image to execute API initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## October 16 2020 - v1.3
+* API configuration is now executed using `cURL` [Docker image](https://hub.docker.com/r/curlimages/curl).
+* `README.md` updated (Solving [https://github.com/fmdlc/ISP-Checker/issues/14](https://github.com/fmdlc/ISP-Checker/issues/14)).
+
 ## October 12 2020 - v1.2
 * Enabling CI build a multi-architecture Docker image (Extending support to `linux/amd64`, `linux/arm/v7`, `linux/arm64`)
 * Fixing Docker images version on Docker Compose.

--- a/ISP-Checker/Makefile
+++ b/ISP-Checker/Makefile
@@ -24,17 +24,17 @@ install:
 	@sleep 10
 
 	$(info Make: Initializing datasources and dashboards)
-	@curl -s --location -X POST 'http://admin:admin@localhost:3000/api/datasources' \
-		--header 'Content-Type: application/json' \
-		-d @./grafana/datasource.json > /dev/null
+	@docker run --network host -v "$(PWD)/grafana:/app" --rm curlimages/curl:7.73.0 \
+		-s --location -XPOST 'http://admin:admin@127.0.0.1:3000/api/datasources' \
+		--header 'Content-Type: application/json' -d @/app/datasource.json > /dev/null
 
-	@curl -s --location -X POST 'http://admin:admin@localhost:3000/api/dashboards/db' \
-		--header 'Content-Type: application/json' \
-		-d @./grafana/network-dashboard.json > /dev/null
+	@docker run --network host -v "$(PWD)/grafana:/app" --rm curlimages/curl:7.73.0 \
+		-s --location -XPOST 'http://admin:admin@127.0.0.1:3000/api/dashboards/db' \
+		--header 'Content-Type: application/json' -d @/app/network-dashboard.json > /dev/null
 
-	@curl -s --location -X PUT 'http://admin:admin@localhost:3000/api/user/preferences' \
-		--header 'Content-Type: application/json' \
-		-d @./grafana/default.json > /dev/null
+	@docker run --network host -v "$(PWD)/grafana:/app" --rm curlimages/curl:7.73.0 \
+		-s --location -XPUT 'http://admin:admin@127.0.0.1:3000/api/user/preferences' \
+		--header 'Content-Type: application/json' -d @/app/default.json > /dev/null
 
 	@echo "\nOpen your browser a points to http://127.0.0.1:3000/\n"
 	@echo "Default Username: admin | Default Password: admin"

--- a/README.md
+++ b/README.md
@@ -41,11 +41,23 @@ The following platforms are supported:
 You can easily import this dashboard into your current Grafana installation getting it from the Official's [Grafana repository](https://grafana.com/grafana/dashboards/13140).
 
 ### Configuration
-
 Make sure you have the [Docker-CE](https://phoenixnap.com/kb/docker-on-raspberry-pi) and [cURL](https://curl.haxx.se/) installed on your *Raspberry Pi*. If you don't, install it using your prefer method.
 ```bash
 $ curl -fsSL https://get.docker.com -o get-docker.sh | bash -
 ```
+
+#### docker-compose
+You need to have `docker-compose` installed. To install it execute:
+
+```bash
+$: sudo curl -L "https://github.com/docker/compose/releases/download/1.27.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+```
+
+Alternatively you can install it using `pip`:
+```bash
+$: pip install docker-compose
+```
+
 Configure the `./ISP-Checker/credentials.env` file.
 There are two users:
 * <ins>Read-Only user:</ins> Used by Grafana to acccess to metrics


### PR DESCRIPTION
## October 16 2020 - v1.3
* API configuration is now executed using `cURL` [Docker image](https://hub.docker.com/r/curlimages/curl).
* `README.md` updated (Solving [https://github.com/fmdlc/ISP-Checker/issues/14](https://github.com/fmdlc/ISP-Checker/issues/14)).
