### PR TITLE
fix(kubernetes): do not assign a vip statically

### DIFF
--- a/kubernetes/ISP-Checker-deploy.yaml
+++ b/kubernetes/ISP-Checker-deploy.yaml
@@ -11016,7 +11016,6 @@ metadata:
   name: influxdb-svc
   namespace: monitoring
 spec:
-  clusterIP: 10.43.37.100
   ports:
   - port: 8086
     protocol: TCP


### PR DESCRIPTION
The VIP could not be in the service ip subnet of the running cluster.
Besides, I see no need to statically assign an IP to the Kubernetes Service.